### PR TITLE
[GITHUB ACTION] Arrête d'exécuter le workflow inutilement.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,21 @@
 name: Build DEV Jars
-on: [push, pull_request]
+on: 
+  pull_request:
+    paths-ignore:
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+  push:
+    paths-ignore:
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
 jobs:
   build_dev_jars:
     name: Build DEV jars


### PR DESCRIPTION
Quand certains fichiers autres que le code sont modifiés, le workflow n'est maintenant pas exécuté, afin d'éviter de faire des builds inutiles sans aucun changement à l'intérieur. Ces fichiers sont : 
.github/PULL_REQUEST_TEMPLATE.md
.gitignore
LICENSE
CODE_OF_CONDUCT.md
CONTRIBUTING.md
README.md
