### PR TITLE
Correction du Quiz et du Tpa

### DIFF
--- a/src/main/java/fr/communaywen/core/QuizManager.java
+++ b/src/main/java/fr/communaywen/core/QuizManager.java
@@ -75,7 +75,6 @@ public class QuizManager {
                 @Override
                 public void run() {
 
-                    Bukkit.broadcastMessage(
             Bukkit.broadcastMessage(
                     "§7\n" +
                             "§7\n" +
@@ -87,20 +86,12 @@ public class QuizManager {
                             "§7\n" +
                             "§8§m                                                     §r" +
                             "§7\n" +
-                                    "§7\n" +
-                                    "§8§m                                                     §r\n" +
-                                    "§7\n" +
-                                    "§6Bravo à §7" + event.getPlayer().getDisplayName() + " §6qui trouve la réponse en premier ! \n§7" +
-                                    "§eLa réponse au quizz étais §7" + currentQuiz.answer + ". \n§7" +
-                                    "§bIl remporte §7" + money + " §bde monnaie !\n" +
-                                    "§7\n" +
-                                    "§8§m                                                     §r" +
-                                    "§7\n" +
-                                    "§7\n"
-                    );
+                            "§7\n"
+            );
 
 
                 }
+
             };
 
             task.runTaskLater((Plugin) this, 10 * 3);

--- a/src/main/java/fr/communaywen/core/QuizManager.java
+++ b/src/main/java/fr/communaywen/core/QuizManager.java
@@ -94,7 +94,7 @@ public class QuizManager {
 
             };
 
-            task.runTaskLater((Plugin) this, 10 * 3);
+            task.runTaskLater((Plugin) this, 10);
         }
 
             event.setCancelled(true);

--- a/src/main/java/fr/communaywen/core/QuizManager.java
+++ b/src/main/java/fr/communaywen/core/QuizManager.java
@@ -3,6 +3,8 @@ package fr.communaywen.core;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.Debug;
 
 import java.text.MessageFormat;
@@ -68,26 +70,38 @@ public class QuizManager {
         if (currentQuiz == null) return;
 
         if (event.getMessage().toLowerCase().equals(currentQuiz.answer)) {
-            Bukkit.broadcastMessage(
-                    "§7\n" +
+            BukkitRunnable task = new BukkitRunnable() {
+                @Override
+                public void run() {
+
+                    Bukkit.broadcastMessage(
                             "§7\n" +
-                            "§8§m                                                     §r\n" +
-                            "§7\n" +
-                            "§6Bravo à §7" + event.getPlayer().getDisplayName() + " §6qui trouve la réponse en premier ! \n§7" +
-                            "§eLa réponse au quizz étais §7" + currentQuiz.answer + ". \n§7" +
-                            "§bIl remporte §7" + money + " §bde monnaie !\n" +
-                            "§7\n" +
-                            "§8§m                                                     §r" +
-                            "§7\n" +
-                            "§7\n"
-            );
+                                    "§7\n" +
+                                    "§8§m                                                     §r\n" +
+                                    "§7\n" +
+                                    "§6Bravo à §7" + event.getPlayer().getDisplayName() + " §6qui trouve la réponse en premier ! \n§7" +
+                                    "§eLa réponse au quizz étais §7" + currentQuiz.answer + ". \n§7" +
+                                    "§bIl remporte §7" + money + " §bde monnaie !\n" +
+                                    "§7\n" +
+                                    "§8§m                                                     §r" +
+                                    "§7\n" +
+                                    "§7\n"
+                    );
+
+
+                }
+            };
+
+            task.runTaskLater((Plugin) this, 10 * 3);
+        }
+
             event.setCancelled(true);
             this.plugin.economyManager.addBalance(event.getPlayer(), money);
             currentQuiz = null;
             this.timeoutExecutor.shutdownNow();
             this.timeoutExecutor = Executors.newScheduledThreadPool(1);
         }
-    }
+
 
     public void close() {
         executor.shutdownNow();

--- a/src/main/java/fr/communaywen/core/tpa/TPACommand.java
+++ b/src/main/java/fr/communaywen/core/tpa/TPACommand.java
@@ -6,8 +6,11 @@ import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import revxrsal.commands.annotation.Command;
 import revxrsal.commands.annotation.Named;
 import revxrsal.commands.bukkit.annotation.CommandPermission;
@@ -30,8 +33,15 @@ public class TPACommand {
                 return;
             }
 
+        if (tpQueue.TPA_REQUESTS2.containsKey(player)) {
+            player.sendMessage("Vous avez déjà une demande de téléportation en attente...");
+            return;
+        }
+
+
             tpQueue.TPA_REQUESTS.put(target, player);
             tpQueue.TPA_REQUESTS2.put(player, target);
+
             player.sendMessage("Vous avez envoyé une demande de tpa à " + target.getName());
 
             final TextComponent textComponent = Component.text(player.getName() + " vous a envoyé un demande de téléportation faites /tpaccept pour l'accepter")
@@ -40,5 +50,26 @@ public class TPACommand {
                     .hoverEvent(HoverEvent.showText(Component.text("§7[§aClique pour accepter§7]")));
 
             plugin.getAdventure().player(target).sendMessage(textComponent);
+
+        BukkitRunnable task = new BukkitRunnable() {
+            @Override
+            public void run() {
+
+
+                if (tpQueue.TPA_REQUESTS2.containsKey(player)) {
+                    player.sendMessage("Votre demande de téléportation a expirée...");
+
+                    tpQueue.TPA_REQUESTS.remove(target, player);
+                    tpQueue.TPA_REQUESTS2.remove(player, target);
+
+                }
+
+
+            }
+        };
+
+        task.runTaskLater((Plugin) this, 2400 * 3);
     }
+
 }
+

--- a/src/main/java/fr/communaywen/core/tpa/TPACommand.java
+++ b/src/main/java/fr/communaywen/core/tpa/TPACommand.java
@@ -68,7 +68,7 @@ public class TPACommand {
             }
         };
 
-        task.runTaskLater((Plugin) this, 2400 * 3);
+        task.runTaskLater((Plugin) this, 2400);
     }
 
 }

--- a/src/main/java/fr/communaywen/core/tpa/TpacceptCommand.java
+++ b/src/main/java/fr/communaywen/core/tpa/TpacceptCommand.java
@@ -20,8 +20,8 @@ public class TpacceptCommand {
             return;
         }
         tpQueue.TPA_REQUESTS.remove(player);
-        player.sendMessage(tpaplayer.getName()+" va être téléporté à vous dans 3 secondes");
-        tpaplayer.sendTitle("§0","Téléportation à "+player.getName()+" dans 3 secondes...",20,10,10);
+        player.sendMessage(tpaplayer.getName()+" va être téléporté à vous !");
+        tpaplayer.sendTitle("§0","Téléportation à "+player.getName() ,20,10,10);
         new BukkitRunnable() {
             @Override
             public void run() {


### PR DESCRIPTION
Quiz :

J'ai fait attendre 1/2 seconde quand le joueur envoie la bonne réponse avant d'envoyer le message de félicitations afin qu'il n'arrive pas avant le message.

Tpa : 

J'ai corrigé des titres et des messages, comme maintenant la téléportation se fait en instantanée, j'ai mis à jour tout ça.

J'ai fait en sorte qu'on ne puisse pas spam les demandes de tpa et qu'on puisse en faire qu'une seule à la fois. 

J'ai également fait en sorte que les requêtes expirent au bout de 2 minutes. 
