### PR TITLE
[Code] Added /wiki command

### DIFF
--- a/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
+++ b/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
@@ -43,6 +43,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+
+import revxrsal.commands.autocomplete.SuggestionProvider;
 import revxrsal.commands.bukkit.BukkitCommandHandler;
 
 
@@ -55,6 +57,7 @@ public final class AywenCraftPlugin extends JavaPlugin {
     private MOTDChanger motdChanger;
     private TeamManager teamManager;
     private FileConfiguration bookConfig;
+    private FileConfiguration wikiConfig;
     private static AywenCraftPlugin instance;
     private FriendsManager friendsManager;
     private CorpseManager corpseManager;
@@ -81,6 +84,14 @@ public final class AywenCraftPlugin extends JavaPlugin {
             saveResource("rules.yml", false);
         }
         bookConfig = YamlConfiguration.loadConfiguration(bookFile);
+    }
+
+    private void loadWikiConfig() {
+        File wikiFile = new File(getDataFolder(), "wiki.yml");
+        if (!wikiFile.exists()) {
+            saveResource("wiki.yml", false);
+        }
+        wikiConfig = YamlConfiguration.loadConfiguration(wikiFile);
     }
 
     private FileConfiguration loadWelcomeMessageConfig() {
@@ -127,6 +138,7 @@ public final class AywenCraftPlugin extends JavaPlugin {
         MenuLib.init(this);
         economyManager = new EconomyManager(getDataFolder());
         loadBookConfig();
+        loadWikiConfig();
 
         LevelsDataManager.setLevelsFile(loadLevelsFile(),new File(getDataFolder(), "levels.yml"));
 
@@ -155,14 +167,14 @@ public final class AywenCraftPlugin extends JavaPlugin {
         this.interactiveHelpMenu = InteractiveHelpMenu.create();
         this.handler.accept(interactiveHelpMenu);
 
+        this.handler.getAutoCompleter().registerSuggestion("featureName", SuggestionProvider.of(wikiConfig.getKeys(false)));
+
         this.handler.register(new SpawnCommand(this), new VersionCommand(this), new RulesCommand(bookConfig),
                 new TeamCommand(), new MoneyCommand(this.economyManager), new ScoreboardCommand(), new ProutCommand(),
                 new FeedCommand(this), new TPACommand(this), new TpacceptCommand(), new TpcancelCommand(), new TpdenyCommand(),
                 new CreditCommand(), new ExplodeRandomCommand(), new LinkCommand(linkerAPI), new ManualLinkCommand(linkerAPI),
                 new RTPCommand(this), new FreezeCommand(), new PlayersCommand(), new FBoomCommand(), new BaltopCommand(this),
-                new FriendsCommand(friendsManager, this, adventure), new PrivacyCommand(this), new LevelCommand(experienceManager), new TailleCommand(),
-                new GithubCommand(this)
-        );
+                new FriendsCommand(friendsManager, this, adventure), new PrivacyCommand(this), new LevelCommand(experienceManager), new TailleCommand(), new WikiCommand(wikiConfig), new GithubCommand(this));
 
         /*  --------  */
 

--- a/src/main/java/fr/communaywen/core/commands/WikiCommand.java
+++ b/src/main/java/fr/communaywen/core/commands/WikiCommand.java
@@ -1,0 +1,71 @@
+package fr.communaywen.core.commands;
+
+import dev.lone.itemsadder.api.CustomStack;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.*;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import revxrsal.commands.annotation.*;
+import revxrsal.commands.bukkit.BukkitCommandHandler;
+import revxrsal.commands.bukkit.annotation.CommandPermission;
+
+import java.util.List;
+
+
+public class WikiCommand {
+
+    private final FileConfiguration wikiConfig;
+
+
+    public WikiCommand(FileConfiguration wikiConfig) {
+        this.wikiConfig = wikiConfig;
+    }
+
+
+
+
+    @Command({"wiki", "info"})
+    @Description("Afficher le lien du wiki de l'item/fonctionnalité")
+    @CommandPermission("ayw.command.wiki")
+    @AutoComplete("@featureName")
+    public void onCommand(Player player, @Named("featureName") @Optional  String itemArg) {
+
+        if(itemArg != null) {
+            player.spigot().sendMessage(getOpenMCWikiChatComponent(itemArg, itemArg));
+            return;
+        }
+
+
+        if (player.getInventory().getItemInMainHand().getItemMeta() != null) {
+            CustomStack customStack = CustomStack.byItemStack(player.getInventory().getItemInMainHand());
+            if (customStack != null) {
+                player.spigot().sendMessage(getOpenMCWikiChatComponent(customStack.getId(), customStack.getDisplayName()));
+            } else {
+                String link = "https://minecraft.wiki/w/"+player.getInventory().getItemInMainHand().getType().name().toLowerCase();
+                TranslatableComponent itemName = new TranslatableComponent(player.getInventory().getItemInMainHand().getType().getTranslationKey());
+                BaseComponent[] component =
+                        new ComponentBuilder("§eVoici le lien du wiki de l'item ").append(itemName).color(ChatColor.GOLD).append(" §e: §6Minecraft Wiki")
+                                .event(new ClickEvent(ClickEvent.Action.OPEN_URL, link))
+                                .create();
+                player.spigot().sendMessage(component);
+            }
+        } else {
+            player.sendMessage("§cVous devez tenir un item en main ou spécifier une feature pour utiliser cette commande.");
+        }
+
+
+    }
+
+    public BaseComponent[] getOpenMCWikiChatComponent(String name, String displayName) {
+        String link = wikiConfig.getString(name);
+        if(link == null) {
+            return new ComponentBuilder("§cLe lien du wiki de cet item ou feature n'est pas encore disponible.").create();
+        }
+
+        BaseComponent[] component =
+                new ComponentBuilder("§eVoici le lien du wiki de l'item ou de la feature ").append(displayName).color(ChatColor.GOLD).append(" §e: §6OpenMC Wiki")
+                        .event(new ClickEvent(ClickEvent.Action.OPEN_URL, link))
+                        .create();
+        return component;
+    }
+}

--- a/src/main/resources/wiki.yml
+++ b/src/main/resources/wiki.yml
@@ -1,0 +1,6 @@
+hammer: "https://wiki.openmc.fr/features/marteau-de-thor"
+teams: "https://wiki.openmc.fr/commandes/gestion-des-teams"
+dormir: "https://wiki.openmc.fr/features/dormir"
+fun: "https://wiki.openmc.fr/commandes/fun"
+prout: "https://wiki.openmc.fr/commandes/fun"
+contribuer: "https://wiki.openmc.fr/contribuer"


### PR DESCRIPTION
Pour les items "customs", récupère les entrées depuis la config (wiki.yml)
Pour les items "vanilla", récupère l'id de l'item (e.g: minecraft:**stone**) et l'ajoute à l'url https://minecraft.wiki/w/ (e.g: https://minecraft.wiki/w/stone)