### PR TITLE
Ajout de la commande /trade

### DIFF
--- a/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
+++ b/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
@@ -19,6 +19,10 @@ import fr.communaywen.core.tpa.TpacceptCommand;
 import fr.communaywen.core.tpa.TpcancelCommand;
 import fr.communaywen.core.tpa.TpdenyCommand;
 
+import fr.communaywen.core.trade.TradeCommand;
+import fr.communaywen.core.trade.TradeListener;
+import fr.communaywen.core.trade.TradeAcceptCommand;
+
 import fr.communaywen.core.economy.EconomyManager;
 import dev.xernas.menulib.MenuLib;
 import fr.communaywen.core.utils.command.InteractiveHelpMenu;
@@ -174,7 +178,7 @@ public final class AywenCraftPlugin extends JavaPlugin {
                 new FeedCommand(this), new TPACommand(this), new TpacceptCommand(), new TpcancelCommand(), new TpdenyCommand(),
                 new CreditCommand(), new ExplodeRandomCommand(), new LinkCommand(linkerAPI), new ManualLinkCommand(linkerAPI),
                 new RTPCommand(this), new FreezeCommand(), new PlayersCommand(), new FBoomCommand(), new BaltopCommand(this),
-                new FriendsCommand(friendsManager, this, adventure), new PrivacyCommand(this), new LevelCommand(experienceManager), new TailleCommand(), new WikiCommand(wikiConfig), new GithubCommand(this));
+                new FriendsCommand(friendsManager, this, adventure), new PrivacyCommand(this), new LevelCommand(experienceManager), new TailleCommand(), new WikiCommand(wikiConfig), new GithubCommand(this), new TradeCommand(this), new TradeAcceptCommand(this));
 
         /*  --------  */
 
@@ -206,6 +210,7 @@ public final class AywenCraftPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayersMenuListener(), this);
         getServer().getPluginManager().registerEvents(new TablistListener(this), this);
         getServer().getPluginManager().registerEvents(new CorpseListener(corpseManager), this);
+        getServer().getPluginManager().registerEvents(new TradeListener(), this);
         /* --------- */
 
         saveDefaultConfig();

--- a/src/main/java/fr/communaywen/core/trade/Trade.java
+++ b/src/main/java/fr/communaywen/core/trade/Trade.java
@@ -1,0 +1,230 @@
+package fr.communaywen.core.trade;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import fr.communaywen.core.AywenCraftPlugin;
+import fr.communaywen.core.utils.Queue;
+
+
+// Partie principalement réalisée par Armibule
+
+public class Trade implements Listener {
+    // current trade requests (there is one entry for each player, static)
+    public static final Queue<Player, Trade> tradesPlayer1 = new Queue<>(20);
+    public static final Queue<Player, Trade> tradesPlayer2 = new Queue<>(20);
+
+    private AywenCraftPlugin plugin;
+
+
+    public static Trade makeNewTrade(Player player1, Player player2, double money1, double money2, AywenCraftPlugin plugin) {
+        Trade trade = new Trade(player1, player2, money1, money2, plugin);
+
+        tradesPlayer1.add(player1, trade);
+        tradesPlayer2.add(player2, trade);
+
+        return trade;
+    }
+
+    // trade instances
+    public Player player1;
+    public Player player2;
+
+    public double money1;
+    public double money2;
+
+    public Inventory inventory1;
+    public Inventory inventory2;
+
+    public boolean accepted1 = false;
+    public boolean accepted2 = false;
+
+    private Trade(Player player1, Player player2, double money1, double money2, AywenCraftPlugin plugin) {
+        this.player1 = player1;
+        this.player2 = player2;
+
+        this.money1 = money1;
+        this.money2 = money2;
+
+        this.inventory1 = Bukkit.createInventory(null, 9, "[Trade] Envoyer à " + player2.getName()/* + " 0$"*/);
+        this.inventory2 = Bukkit.createInventory(null, 9, "[Trade] Envoyer à " + player1.getName()/* + " 0$"*/);
+
+        this.plugin = plugin;
+    }
+
+    public boolean isLocked() {
+        return accepted1 | accepted2;
+    }
+
+    public void openOwnItems(boolean isPlayer1) {
+        if (isPlayer1) {
+            player1.openInventory(inventory1);
+        } else {
+            player2.openInventory(inventory2);
+        }
+    }
+
+    public void openOtherItems(boolean isPlayer1) {
+        if (isPlayer1) {
+            player1.openInventory(inventory2);
+        } else {
+            player2.openInventory(inventory1);
+        }
+    }
+
+    public boolean setMoney1(double value) {
+        boolean success = plugin.economyManager.withdrawBalance(player1, value - money1);
+
+        if (!success) {            
+            return false;
+        }
+
+        money1 = value;
+        return true;
+    }
+
+    public boolean setMoney2(double value) {
+        boolean success = plugin.economyManager.withdrawBalance(player2, value - money1);
+
+        if (!success) {            
+            return false;
+        }
+
+        money2 = value;
+        return true;
+    }
+
+    public void cancel() {
+        plugin.economyManager.addBalance(player1, money1);
+        plugin.economyManager.addBalance(player2, money2);
+
+        World player1World = player1.getWorld();
+        Location player1Location = player1.getLocation();
+
+        for (ItemStack stack : inventory1.getContents()) {
+            if (stack != null) {
+                Collection<ItemStack> leftItems = player1.getInventory().addItem(
+                    stack
+                ).values();
+
+                if (leftItems.size() > 0) {
+                    for (ItemStack leftStack : leftItems) {
+                        player1World.dropItemNaturally(player1Location, leftStack);
+                    }
+                }
+            }
+        }
+
+
+        World player2World = player2.getWorld();
+        Location player2Location = player2.getLocation();
+
+        for (ItemStack stack : inventory2.getContents()) {
+            if (stack != null) {
+                Collection<ItemStack> leftItems = player2.getInventory().addItem(
+                    stack
+                ).values();
+
+                if (leftItems.size() > 0) {
+                    for (ItemStack leftStack : leftItems) {
+                        player2World.dropItemNaturally(player2Location, leftStack);
+                    }
+                }
+            }
+        }
+
+        player1.playSound(player1.getEyeLocation(), Sound.ITEM_SHIELD_BREAK, 1, 1);
+        player2.playSound(player2.getEyeLocation(), Sound.ITEM_SHIELD_BREAK, 1, 1);
+        player1.sendMessage("§6Trade annulé !");
+        player2.sendMessage("§6Trade annulé !");
+
+        delete();
+    }
+
+    public void hasConcluded(boolean isPlayer1) {
+        if (isPlayer1) {
+            accepted1 = true;
+        } else {
+            accepted2 = true;
+        }
+
+        if (accepted1 && accepted2) {
+            conclude();
+        }
+    }
+
+    public void conclude() {
+        plugin.economyManager.addBalance(player2, money1);
+        plugin.economyManager.addBalance(player1, money2);
+
+        
+        World player1World = player1.getWorld();
+        Location player1Location = player1.getLocation();
+
+        for (ItemStack stack : inventory2.getContents()) {
+            if (stack != null) {
+                Collection<ItemStack> leftItems = player1.getInventory().addItem(
+                    stack
+                ).values();
+
+                if (leftItems.size() > 0) {
+                    for (ItemStack leftStack : leftItems) {
+                        player1World.dropItemNaturally(player1Location, leftStack);
+                    }
+                }
+            }
+        }
+
+
+        World player2World = player2.getWorld();
+        Location player2Location = player2.getLocation();
+
+        for (ItemStack stack : inventory1.getContents()) {
+            if (stack != null) {
+                Collection<ItemStack> leftItems = player2.getInventory().addItem(
+                    stack
+                ).values();
+
+                if (leftItems.size() > 0) {
+                    for (ItemStack leftStack : leftItems) {
+                        player2World.dropItemNaturally(player2Location, leftStack);
+                    }
+                }
+            }
+        }
+
+        player1.playSound(player1.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_FLUTE, 1, 1);
+        player2.playSound(player2.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_FLUTE, 1, 1);
+        player1.sendMessage("§aTrade réalisé !");
+        player2.sendMessage("§aTrade réalisé !");
+
+        delete();
+    }
+
+    private void delete() {
+        money1 = 0;
+        money2 = 0;
+        inventory1 = null;
+        inventory2 = null;
+
+        tradesPlayer1.remove(player1);
+        tradesPlayer2.remove(player2);
+    }
+
+    // On object destroy
+    @Override
+    protected void finalize() {
+        if (inventory1 != null && inventory2 != null) {
+            cancel();
+        }
+    }
+}

--- a/src/main/java/fr/communaywen/core/trade/TradeAcceptCommand.java
+++ b/src/main/java/fr/communaywen/core/trade/TradeAcceptCommand.java
@@ -1,0 +1,88 @@
+package fr.communaywen.core.trade;
+
+import fr.communaywen.core.AywenCraftPlugin;
+import fr.communaywen.core.utils.Queue;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.Description;
+import revxrsal.commands.bukkit.annotation.CommandPermission;
+
+
+/**
+ * La commande /tradeaccept
+ *
+ * Usage: /tradeaccept
+ * Permission: PREFIX.command.trade
+ */
+public final class TradeAcceptCommand {
+    private AywenCraftPlugin plugin;
+
+    // player2: player1
+    private static final Queue<Player, Player> pendingDemands = new Queue<>(20);
+
+    public TradeAcceptCommand(AywenCraftPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Command("tradeaccept")
+    @Description("Accepter une demande de trade")
+    @CommandPermission("ayw.command.trade")     // TODO
+    public void onCommand(Player player2) {
+        Player player1 = pendingDemands.get(player2);
+
+        if (player1 == null) {
+            player2.sendMessage("§6Tu n'as pas de demande de trade en cours !");
+            return;
+        }
+        pendingDemands.remove(player2);
+
+        Trade trade = Trade.makeNewTrade(player1, player2, 0, 0, plugin);
+
+        trade.openOwnItems(true);
+        trade.openOwnItems(false);
+
+        final TextComponent textComponent = 
+            Component.text("$3Trade avec §9" + player1.getName())
+                .append(
+                    Component.text("\n> §b[§cModifier les items§b] ")
+                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/trade items"))
+                        .hoverEvent(HoverEvent.showText(Component.text("Modifier les items")))
+                        .append(
+                            Component.text("\n> §b[§dModifier l'argent à envoyer§b] ")
+                                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/trade money 0"))
+                                .hoverEvent(HoverEvent.showText(Component.text("Modifier l'argent à envoyer")))
+                                .append(
+                                    Component.text("\n> §b[§dVérifier les items envoyés§b] ")
+                                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/trade check"))
+                                        .hoverEvent(HoverEvent.showText(Component.text("Vérifier les items envoyés par l'autre")))
+                                        .append(
+                                            Component.text("\n> §b[§aConclure le trade§b] ")
+                                                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/trade conclude"))
+                                                .hoverEvent(HoverEvent.showText(Component.text("Accepter et conclure le trade")))
+                                                .append(
+                                                    Component.text("\n> §b[§cAnnuler le trade§b] ")
+                                                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/trade cancel"))
+                                                        .hoverEvent(HoverEvent.showText(Component.text("Annuler le trade")))
+                                                )
+                                        )
+                                )
+                        )
+                );
+                
+        plugin.getAdventure().player(player1).sendMessage(textComponent);
+        player1.playSound(player1.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, 1, 1);
+        plugin.getAdventure().player(player2).sendMessage(textComponent);
+        player2.playSound(player2.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, 1, 1);
+    }
+
+    public static void newPendingDemand(Player player1, Player player2) {
+        pendingDemands.add(player2, player1);
+    }
+}

--- a/src/main/java/fr/communaywen/core/trade/TradeCommand.java
+++ b/src/main/java/fr/communaywen/core/trade/TradeCommand.java
@@ -1,0 +1,224 @@
+package fr.communaywen.core.trade;
+
+import fr.communaywen.core.AywenCraftPlugin;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.TextColor;
+
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.DefaultFor;
+import revxrsal.commands.annotation.Description;
+import revxrsal.commands.annotation.Subcommand;
+import revxrsal.commands.bukkit.annotation.CommandPermission;
+
+
+/**
+ * La commande /trade
+ *
+ * Usage: /trade [player]
+ * Permission: PREFIX.command.trade
+ */
+@Command("trade")
+@Description("Gestion des trades")
+@CommandPermission("ayw.command.trade")
+public final class TradeCommand {
+    private AywenCraftPlugin plugin;
+
+    public TradeCommand(AywenCraftPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @DefaultFor("~")
+    @Description("Echanger des items et de l'argent avec un autre joueur")
+    @CommandPermission("ayw.command.trade")
+    public void onCommand(Player player1, Player player2) {
+
+        if (Trade.tradesPlayer1.get(player1) != null || Trade.tradesPlayer2.get(player1) != null) {
+            player1.sendMessage("§6Tu as déjà un trade en cours !");
+            return;
+        }
+
+        if (player2 == null) {
+            player1.sendMessage("§6Il faut spécifier un joueur !\nExemple: /trade Aywen");
+            return;
+        }
+
+        if (player1 == player2) {
+            player1.sendMessage("§6Tu ne peux pas te faire une demande de trade !");
+            return;
+        }
+
+        final TextComponent textComponent = Component.text("§9" + player1.getName() + " §3vous a envoyé un demande de trade, /tradeaccept pour l'accepter")
+                    .color(TextColor.color(255,255,255))
+                    .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/tradeaccept"))
+                    .hoverEvent(HoverEvent.showText(Component.text("§7[§aClique pour accepter§7]")));
+
+        TradeAcceptCommand.newPendingDemand(player1, player2);
+
+        plugin.getAdventure().player(player2).sendMessage(textComponent);
+        player2.playSound(player2.getEyeLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, 1, 1);
+
+        player1.sendMessage("§aLa demande de trade a été envoyée à " + player2.getName());
+    }
+
+    @Subcommand("money")
+    @Description("Définir l'argent à envoyer")
+    @CommandPermission("ayw.command.trade")
+    public void moneyCmd(Player player, double moneytoPay) {
+
+        boolean isPlayer1;
+
+        Trade trade = Trade.tradesPlayer1.get(player);
+        if (trade == null) {
+            trade = Trade.tradesPlayer2.get(player);
+
+            if (trade == null) {
+                player.sendMessage("§6Tu n'as pas de trade en cours !");
+                return;
+            }
+
+            isPlayer1 = false;
+        } else {
+            isPlayer1 = true;
+        }
+
+        if (trade.isLocked()) {
+            player.sendMessage("§6L'autre joueur a bloqué le trade !");
+            return;
+        }
+
+        /*if (moneyToPay == null) {
+            player.sendMessage("§6Il faut spécifier une valeur !\nExemple: /trade money 200");
+            return;
+        }*/
+
+        if (moneytoPay < 0) {
+            player.sendMessage("§6Il faut un nombre positif !");
+            return;
+        }
+
+        boolean success;
+
+        if (isPlayer1) {
+            success = trade.setMoney1(moneytoPay);
+        } else {
+            success = trade.setMoney2(moneytoPay);
+        }
+
+        if (!success) {
+            player.sendMessage("§6Tu n'as pas assez d'argent ! (" + plugin.economyManager.getBalance(player) + ")");
+            return;
+        }
+
+        player.sendMessage("§aL'argent à envoyer a bien été défini à " + moneytoPay + "$");
+
+        if (isPlayer1) {
+            trade.player2.sendMessage("§b" + player.getName() + " a modifié l'argent à envoyer " + moneytoPay + "$");
+        } else {
+            trade.player1.sendMessage("§b" + player.getName() + " a modifié l'argent à envoyer " + moneytoPay + "$");
+        }
+    }
+
+    @Subcommand("items")
+    @Description("Définir les items à envoyer")
+    @CommandPermission("ayw.command.trade")
+    public void itemsCmd(Player player) {
+
+        boolean isPlayer1;
+
+        Trade trade = Trade.tradesPlayer1.get(player);
+        if (trade == null) {
+            trade = Trade.tradesPlayer2.get(player);
+
+            if (trade == null) {
+                player.sendMessage("§6Tu n'as pas de trade en cours !");
+                return;
+            }
+
+            isPlayer1 = false;
+        } else {
+            isPlayer1 = true;
+        }
+
+        if (trade.isLocked()) {
+            player.sendMessage("§6L'autre joueur a bloqué le trade !");
+            return;
+        }
+
+        trade.openOwnItems(isPlayer1);
+    }
+
+    @Subcommand("check")
+    @Description("Vérifier les items envoyés par l'autre")
+    @CommandPermission("ayw.command.trade")
+    public void checkCmd(Player player) {
+
+        boolean isPlayer1;
+
+        Trade trade = Trade.tradesPlayer1.get(player);
+        if (trade == null) {
+            trade = Trade.tradesPlayer2.get(player);
+
+            if (trade == null) {
+                player.sendMessage("§6Tu n'as pas de trade en cours !");
+                return;
+            }
+
+            isPlayer1 = false;
+        } else {
+            isPlayer1 = true;
+        }
+
+        if (isPlayer1) {
+            trade.player1.sendMessage("$bArgent qui sera envoyé par " + trade.player2.getName() + " : §a" + trade.money2 + "$");
+        } else {
+            trade.player2.sendMessage("$bArgent qui sera envoyé par " + trade.player1.getName() + " : §a" + trade.money1 + "$");
+        }
+
+        trade.openOtherItems(isPlayer1);
+    }
+
+    @Subcommand("cancel")
+    @Description("Annule le trade")
+    @CommandPermission("ayw.command.trade")
+    public void cancelCmd(Player player) {
+        Trade trade = Trade.tradesPlayer1.get(player);
+        if (trade == null) {
+            trade = Trade.tradesPlayer2.get(player);
+
+            if (trade == null) {
+                player.sendMessage("§6Tu n'as pas de trade en cours !");
+                return;
+            }
+        }
+
+        trade.cancel();
+    }
+
+    @Subcommand("conclude")
+    @Description("Conclus le trade")
+    @CommandPermission("ayw.command.trade")
+    public void concludeCmd(Player player) {
+        boolean isPlayer1;
+
+        Trade trade = Trade.tradesPlayer1.get(player);
+        if (trade == null) {
+            trade = Trade.tradesPlayer2.get(player);
+
+            if (trade == null) {
+                player.sendMessage("§6Tu n'as pas de trade en cours !");
+                return;
+            }
+
+            isPlayer1 = false;
+        } else {
+            isPlayer1 = true;
+        }
+
+        trade.hasConcluded(isPlayer1);
+    }
+}

--- a/src/main/java/fr/communaywen/core/trade/TradeListener.java
+++ b/src/main/java/fr/communaywen/core/trade/TradeListener.java
@@ -1,0 +1,47 @@
+package fr.communaywen.core.trade;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+
+public class TradeListener implements Listener {
+    @EventHandler
+    public void onInventoryClick(final InventoryClickEvent e) {
+        Trade trade = Trade.tradesPlayer1.get((Player) e.getWhoClicked());
+        if (trade == null) {
+            trade = Trade.tradesPlayer2.get((Player) e.getWhoClicked());
+            if (trade == null) {
+                return;
+            }
+
+            if (trade.inventory1 == e.getClickedInventory()) {
+                e.setCancelled(true);
+            }
+        } else {
+            if (trade.inventory2 == e.getClickedInventory()) {
+                e.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(final InventoryDragEvent e) {
+        Trade trade = Trade.tradesPlayer1.get((Player) e.getWhoClicked());
+        if (trade == null) {
+            trade = Trade.tradesPlayer2.get((Player) e.getWhoClicked());
+            if (trade == null) {
+                return;
+            }
+
+            if (trade.inventory1 == e.getInventory()) {
+                e.setCancelled(true);
+            }
+        } else {
+            if (trade.inventory2 == e.getInventory()) {
+                e.setCancelled(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Fonctionnement
 - /trade [player] : Lance un trade avec un joueur

*Les commades ci-dessous peuvent être lancées en cliquant sur les messages du chat*

 - /tradeaccept : accepte la demande de trade
 - /trade items : permet de modifier les items à envoyer
 - /trade money [value] : modifie l'argent à envoyer
 - /trade check : permet de voir les items de l'argent envoyé par l'autre joueur
 - /trade cancel : annule le trade
 - /trade conclude : valide et bloque le trade

## Commentaires
C'est n'est pas parfait et il y a des voies d'amélioration mais au vu de la date de sortie du server, je n'aurai pas le temps de finir.
*Il faut aussi noter que je n'ai pu tester le plugin qu'en solo et qu'il peut demerer quelques petits soucis*
