### PR TITLE
Feature/waypoints

### DIFF
--- a/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
+++ b/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
@@ -51,7 +51,6 @@ import revxrsal.commands.bukkit.BukkitCommandHandler;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.io.File;

--- a/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
+++ b/src/main/java/fr/communaywen/core/AywenCraftPlugin.java
@@ -27,6 +27,7 @@ import fr.communaywen.core.trade.TradeCommand;
 import fr.communaywen.core.trade.TradeListener;
 import fr.communaywen.core.utils.*;
 import fr.communaywen.core.utils.command.InteractiveHelpMenu;
+import fr.communaywen.core.waypoints.commands.WaypointCommand;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
@@ -167,7 +168,8 @@ public final class AywenCraftPlugin extends JavaPlugin {
                 new FeatureCommand(managers.getFeatureManager()),
                 new MineCommand(),
                 new AdminShopCommand(),
-                new PayCommands()
+                new PayCommands(),
+                new WaypointCommand(managers.getWaypointManager())
         );
 
         /*  --------  */

--- a/src/main/java/fr/communaywen/core/Managers.java
+++ b/src/main/java/fr/communaywen/core/Managers.java
@@ -15,6 +15,7 @@ import fr.communaywen.core.utils.ConfigUtils;
 import fr.communaywen.core.utils.FallingBlocksExplosionManager;
 import fr.communaywen.core.utils.database.Blacklist;
 import fr.communaywen.core.utils.database.DatabaseManager;
+import fr.communaywen.core.waypoints.commands.WaypointManager;
 import lombok.Getter;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -38,12 +39,14 @@ public class Managers {
     private QuizManager quizManager;
     private FallingBlocksExplosionManager fbeManager;
     private LevelsManager levelsManager;
+    private WaypointManager waypointManager;
 
     private FileConfiguration bookConfig;
     private FileConfiguration wikiConfig;
     private FileConfiguration welcomeMessageConfig;
     private FileConfiguration levelsConfig;
     private FileConfiguration quizzesConfig;
+    private FileConfiguration waypointConfig;
 
     public void initConfig(AywenCraftPlugin plugin) {
         plugin.saveDefaultConfig();
@@ -52,6 +55,7 @@ public class Managers {
         welcomeMessageConfig = ConfigUtils.loadConfig(plugin, "welcomeMessageConfig.yml");
         levelsConfig = ConfigUtils.loadConfig(plugin, "levels.yml");
         quizzesConfig = ConfigUtils.loadConfig(plugin, "quizzes.yml");
+        waypointConfig = ConfigUtils.loadConfig(plugin, "waypoints.yml");
     }
 
     public void init(AywenCraftPlugin plugin) {
@@ -87,6 +91,7 @@ public class Managers {
         corpseManager = new CorpseManager();
         fbeManager = new FallingBlocksExplosionManager();
         levelsManager = new LevelsManager();
+        waypointManager = new WaypointManager(waypointConfig);
 
         LevelsDataManager.setLevelsFile(levelsConfig, new File(plugin.getDataFolder(), "levels.yml"));
         LevelsDataManager.setLevelsFile(levelsConfig, new File(plugin.getDataFolder(), "levels.yml"));

--- a/src/main/java/fr/communaywen/core/Managers.java
+++ b/src/main/java/fr/communaywen/core/Managers.java
@@ -15,13 +15,11 @@ import fr.communaywen.core.utils.ConfigUtils;
 import fr.communaywen.core.utils.FallingBlocksExplosionManager;
 import fr.communaywen.core.utils.database.Blacklist;
 import fr.communaywen.core.utils.database.DatabaseManager;
-import fr.communaywen.core.waypoints.commands.WaypointManager;
+import fr.communaywen.core.waypoints.managers.WaypointManager;
 import lombok.Getter;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
-import java.sql.Connection;
 import java.sql.SQLException;
 
 @Credit("Xernas")

--- a/src/main/java/fr/communaywen/core/utils/database/DatabaseManager.java
+++ b/src/main/java/fr/communaywen/core/utils/database/DatabaseManager.java
@@ -49,6 +49,7 @@ public class DatabaseManager {
         this.getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS events_rewards (player VARCHAR(36) NOT NULL PRIMARY KEY, scope VARCHAR(32) NOT NULL, isClaimed BOOLEAN)").executeUpdate();
         this.getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS teams_player (teamName VARCHAR(16) NOT NULL, player VARCHAR(36) NOT NULL)").executeUpdate();
         this.getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS teams (teamName VARCHAR(16) NOT NULL PRIMARY KEY, owner VARCHAR(36) NOT NULL, balance BIGINT UNSIGNED, inventory LONGBLOB)").executeUpdate();
+        this.getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS waypoints (player_uuid VARCHAR(36) NOT NULL, waypoint_name VARCHAR(32) NOT NULL, x DOUBLE NOT NULL, y DOUBLE NOT NULL, z DOUBLE NOT NULL, world VARCHAR(32) NOT NULL, date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)").executeUpdate();
 
         // Système de claims
         this.getConnection().prepareStatement("CREATE TABLE IF NOT EXISTS claim (" +

--- a/src/main/java/fr/communaywen/core/utils/database/Waypoints.java
+++ b/src/main/java/fr/communaywen/core/utils/database/Waypoints.java
@@ -1,5 +1,6 @@
 package fr.communaywen.core.utils.database;
 
+import fr.communaywen.core.waypoints.Waypoint;
 import org.bukkit.Location;
 import org.bukkit.World;
 
@@ -51,8 +52,8 @@ public class Waypoints extends DatabaseConnector {
         return true;
     }
 
-    public static List<String> getWaypoints(String playerUUID) {
-        List<String> waypoints = new ArrayList<>();
+    public static List<Waypoint> getWaypoints(String playerUUID) {
+        List<Waypoint> waypoints = new ArrayList<>();
 
         try {
             PreparedStatement statement = connection.prepareStatement("SELECT * FROM waypoints WHERE player_uuid=?");
@@ -60,11 +61,13 @@ public class Waypoints extends DatabaseConnector {
             ResultSet result = statement.executeQuery();
 
             while (result.next()) {
-                waypoints.add(result.getString("waypoint_name") + " -> " +
-                        result.getString("world") +
-                        " - X: " + result.getDouble("x") +
-                        " - Y: " + result.getDouble("y") +
-                        " - Z: " + result.getDouble("z"));
+                waypoints.add(new Waypoint(
+                        result.getString("waypoint_name"),
+                        result.getString("world"),
+                        result.getDouble("x"),
+                        result.getDouble("y"),
+                        result.getDouble("z")
+                ));
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -97,5 +100,26 @@ public class Waypoints extends DatabaseConnector {
             e.printStackTrace();
             return false;
         }
+    }
+
+    public static Waypoint getWaypoint(String playerUUID, String waypointName) {
+        try {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM waypoints WHERE player_uuid=? AND waypoint_name=?");
+            statement.setString(1, playerUUID);
+            statement.setString(2, waypointName);
+            ResultSet result = statement.executeQuery();
+            if (result.next()) {
+                return new Waypoint(
+                        result.getString("waypoint_name"),
+                        result.getString("world"),
+                        result.getDouble("x"),
+                        result.getDouble("y"),
+                        result.getDouble("z")
+                );
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 }

--- a/src/main/java/fr/communaywen/core/utils/database/Waypoints.java
+++ b/src/main/java/fr/communaywen/core/utils/database/Waypoints.java
@@ -1,0 +1,101 @@
+package fr.communaywen.core.utils.database;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Waypoints extends DatabaseConnector {
+
+    public static boolean addWaypoint(String playerUUID, String waypointName, Location location) {
+
+        // Round at 2 decimals MAX
+        double x = Math.round(location.getX() * 100.0) / 100.0;
+        double y = Math.round(location.getY() * 100.0) / 100.0;
+        double z = Math.round(location.getZ() * 100.0) / 100.0;
+        World world = location.getWorld();
+
+        try {
+            PreparedStatement statement = connection.prepareStatement("INSERT INTO waypoints VALUES (?, ?, ?, ?, ?, ?, ?)");
+            statement.setString(1, playerUUID);
+            statement.setString(2, waypointName);
+            statement.setDouble(3, x);
+            statement.setDouble(4, y);
+            statement.setDouble(5, z);
+            statement.setString(6, world.getName());
+            statement.setTimestamp(7, new Timestamp(System.currentTimeMillis()));
+            statement.executeUpdate();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean removeWaypoint(String playerUUID, String waypointName) {
+        try {
+            PreparedStatement statement = connection.prepareStatement("DELETE FROM waypoints WHERE player_uuid=? AND waypoint_name=?");
+            statement.setString(1, playerUUID);
+            statement.setString(2, waypointName);
+            statement.executeUpdate();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        return true;
+    }
+
+    public static List<String> getWaypoints(String playerUUID) {
+        List<String> waypoints = new ArrayList<>();
+
+        try {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM waypoints WHERE player_uuid=?");
+            statement.setString(1, playerUUID);
+            ResultSet result = statement.executeQuery();
+
+            while (result.next()) {
+                waypoints.add(result.getString("waypoint_name") + " -> " +
+                        result.getString("world") +
+                        " - X: " + result.getDouble("x") +
+                        " - Y: " + result.getDouble("y") +
+                        " - Z: " + result.getDouble("z"));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return waypoints;
+    }
+
+    public static int getWaypointsCount(String playerUUID) {
+        try {
+            PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM waypoints WHERE player_uuid=?");
+            statement.setString(1, playerUUID);
+            ResultSet result = statement.executeQuery();
+            result.next();
+            return result.getInt(1);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+
+    public static boolean waypointExist(String playerUUID, String waypointName) {
+        try {
+            PreparedStatement statement = connection.prepareStatement("SELECT * FROM waypoints WHERE player_uuid=? AND waypoint_name=?");
+            statement.setString(1, playerUUID);
+            statement.setString(2, waypointName);
+            ResultSet result = statement.executeQuery();
+            return result.next();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/fr/communaywen/core/utils/database/Waypoints.java
+++ b/src/main/java/fr/communaywen/core/utils/database/Waypoints.java
@@ -12,6 +12,13 @@ import java.util.List;
 
 public class Waypoints extends DatabaseConnector {
 
+    /**
+     * Add a waypoint to the database
+     * @param playerUUID UUID of the player
+     * @param waypointName Name of the waypoint
+     * @param location Location of the waypoint
+     * @return true if the waypoint has been added, false otherwise
+     */
     public static boolean addWaypoint(String playerUUID, String waypointName, Location location) {
 
         // Round at 2 decimals MAX
@@ -38,6 +45,12 @@ public class Waypoints extends DatabaseConnector {
         return true;
     }
 
+    /**
+     * Remove a waypoint from the database by its name
+     * @param playerUUID UUID of the player
+     * @param waypointName Name of the waypoint
+     * @return true if the waypoint has been removed, false otherwise
+     */
     public static boolean removeWaypoint(String playerUUID, String waypointName) {
         try {
             PreparedStatement statement = connection.prepareStatement("DELETE FROM waypoints WHERE player_uuid=? AND waypoint_name=?");
@@ -52,6 +65,11 @@ public class Waypoints extends DatabaseConnector {
         return true;
     }
 
+    /**
+     * Get all waypoints of a player
+     * @param playerUUID UUID of the player
+     * @return List of waypoints
+     */
     public static List<Waypoint> getWaypoints(String playerUUID) {
         List<Waypoint> waypoints = new ArrayList<>();
 
@@ -76,6 +94,11 @@ public class Waypoints extends DatabaseConnector {
         return waypoints;
     }
 
+    /**
+     * Get the number of waypoints of a player
+     * @param playerUUID UUID of the player
+     * @return Number of waypoints
+     */
     public static int getWaypointsCount(String playerUUID) {
         try {
             PreparedStatement statement = connection.prepareStatement("SELECT COUNT(*) FROM waypoints WHERE player_uuid=?");
@@ -89,6 +112,12 @@ public class Waypoints extends DatabaseConnector {
         }
     }
 
+    /**
+     * Check if a waypoint exists
+     * @param playerUUID UUID of the player
+     * @param waypointName Name of the waypoint
+     * @return true if the waypoint exists, false otherwise
+     */
     public static boolean waypointExist(String playerUUID, String waypointName) {
         try {
             PreparedStatement statement = connection.prepareStatement("SELECT * FROM waypoints WHERE player_uuid=? AND waypoint_name=?");
@@ -102,6 +131,12 @@ public class Waypoints extends DatabaseConnector {
         }
     }
 
+    /**
+     * Get a waypoint by its name
+     * @param playerUUID UUID of the player
+     * @param waypointName Name of the waypoint
+     * @return Waypoint object
+     */
     public static Waypoint getWaypoint(String playerUUID, String waypointName) {
         try {
             PreparedStatement statement = connection.prepareStatement("SELECT * FROM waypoints WHERE player_uuid=? AND waypoint_name=?");

--- a/src/main/java/fr/communaywen/core/waypoints/Waypoint.java
+++ b/src/main/java/fr/communaywen/core/waypoints/Waypoint.java
@@ -1,0 +1,21 @@
+package fr.communaywen.core.waypoints;
+
+import lombok.Getter;
+
+@Getter
+public class Waypoint {
+
+    private final String name;
+    private final String worldName;
+    private final double x;
+    private final double y;
+    private final double z;
+
+    public Waypoint(String name, String world, double x, double y, double z) {
+        this.name = name;
+        this.worldName = world;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+}

--- a/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
+++ b/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
@@ -11,7 +11,7 @@ import revxrsal.commands.annotation.*;
 
 import java.util.List;
 
-@Command({"waypoint", "wp", "balise"})
+@Command({"waypoint", "waypoints", "wp", "balise"})
 @Credit("Fnafgameur")
 public class WaypointCommand {
 

--- a/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
+++ b/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
@@ -96,7 +96,14 @@ public class WaypointCommand {
             return;
         }
 
-        StringBuilder message = new StringBuilder("§7---------- §6§lWaypoints §7----------\n");
+        int nbOfWaypoints = waypoints.size();
+        int maxWaypoints = waypointManager.getMaxWaypoints();
+
+        StringBuilder message = new StringBuilder("§7---------- §6§lWaypoints (")
+                .append(nbOfWaypoints)
+                .append("/")
+                .append(maxWaypoints)
+                .append(") §7----------\n");
 
         for (Waypoint waypoint : waypoints) {
 
@@ -156,16 +163,17 @@ public class WaypointCommand {
 
     private void sendHelpMessage(Player player) {
 
-        String message = """
+        String message = String.format("""
                 §7---------- §6§lWaypoints §7----------
                 §7Utilité: §fPermet de poser des balises pour marquer des coordonnées
                 §7Aliases: §b/waypoint§7, §b/wp§7, §b/balise
+                §7Nombre de waypoints MAX : §b%s
                 §7- §bwaypoint §eadd [nom] §7: Ajoute un waypoint
                 §7- §bwaypoint §eremove [nom] §7: Supprime un waypoint
                 §7- §bwaypoint §elist §7: Liste les waypoints
                 §7- §bwaypoint §egoto [nom] §7: Ré-oriente la caméra vers un waypoint
                 §7- §bwaypoint §ecredits §7: Affiche les crédits
-                """;
+                """, waypointManager.getMaxWaypoints());
 
         player.sendMessage(message);
     }

--- a/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
+++ b/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
@@ -2,11 +2,13 @@ package fr.communaywen.core.waypoints.commands;
 
 import fr.communaywen.core.credit.Credit;
 import fr.communaywen.core.utils.database.Waypoints;
+import fr.communaywen.core.waypoints.Waypoint;
+import fr.communaywen.core.waypoints.managers.WaypointManager;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockType;
 import org.bukkit.entity.Player;
-import revxrsal.commands.annotation.Command;
-import revxrsal.commands.annotation.DefaultFor;
-import revxrsal.commands.annotation.Description;
-import revxrsal.commands.annotation.Subcommand;
+import revxrsal.commands.annotation.*;
 
 import java.util.List;
 
@@ -23,6 +25,12 @@ public class WaypointCommand {
     @DefaultFor("~")
     @Description("Gestion des waypoints")
     public void onCommand(Player player) {
+        sendHelpMessage(player);
+    }
+
+    @Subcommand("help")
+    @Description("Affiche l'utilisation de la commande")
+    public void help(Player player) {
         sendHelpMessage(player);
     }
 
@@ -44,6 +52,11 @@ public class WaypointCommand {
             return;
         }
 
+        if (name.length() > 32) {
+            player.sendMessage("§cLe nom du waypoint ne doit pas dépasser 32 caractères (" + name.length() + ")");
+            return;
+        }
+
         boolean successState = Waypoints.addWaypoint(player.getUniqueId().toString(), name, player.getLocation());
 
         if (successState) {
@@ -57,19 +70,27 @@ public class WaypointCommand {
     @Description("Supprime un waypoint")
     public void remove(Player player, String name) {
 
+        boolean waypointExist = Waypoints.waypointExist(player.getUniqueId().toString(), name);
+
+        if (!waypointExist) {
+            player.sendMessage("§cLe waypoint '" + name + "' n'existe pas");
+            return;
+        }
+
         boolean successState = Waypoints.removeWaypoint(player.getUniqueId().toString(), name);
 
         if (successState) {
             player.sendMessage("§aWaypoint '" + name + "' supprimé avec succès");
             return;
         }
-        player.sendMessage("§cErreur lors de la suppression du waypoint, avez-vous bien écrit le nom ?");
+        player.sendMessage("§cErreur lors de la suppression du waypoint");
     }
 
     @Subcommand("list")
     @Description("Liste les waypoints")
     public void list(Player player) {
-        List<String> waypoints = Waypoints.getWaypoints(player.getUniqueId().toString());
+
+        List<Waypoint> waypoints = Waypoints.getWaypoints(player.getUniqueId().toString());
 
         if (waypoints.isEmpty()) {
             player.sendMessage("§cVous n'avez aucun waypoint");
@@ -78,26 +99,73 @@ public class WaypointCommand {
 
         StringBuilder message = new StringBuilder("§7---------- §6§lWaypoints §7----------\n");
 
-        for (String waypoint : waypoints) {
+        for (Waypoint waypoint : waypoints) {
 
             message.append("§7")
                     .append(waypoints.indexOf(waypoint))
-                    .append(" -§e ")
-                    .append(waypoint)
+                    .append(" -§b ")
+                    .append(waypoint.getName())
+                    .append(" §7->§e X: ")
+                    .append(waypoint.getX())
+                    .append(" §7-§e Y: ")
+                    .append(waypoint.getY())
+                    .append(" §7-§e Z: ")
+                    .append(waypoint.getZ())
+                    .append(" §7-§e Monde: ")
+                    .append(waypoint.getWorldName())
                     .append("\n");
         }
 
         player.sendMessage(message.toString());
     }
 
+    @Subcommand("goto")
+    @Description("Ré-oriente le joueur vers un waypoint")
+    public void gotoWaypoint(Player player, String name) {
+
+        Waypoint waypoint = Waypoints.getWaypoint(player.getUniqueId().toString(), name);
+
+        if (waypoint == null) {
+            player.sendMessage("§cLe waypoint '" + name + "' n'existe pas");
+            return;
+        }
+
+        if (!player.getWorld().getName().equals(waypoint.getWorldName())) {
+            player.sendMessage("§cVous ne vous trouvez pas dans le même monde que le waypoint");
+            return;
+        }
+
+        Material blockUnderPlayer = player.getLocation().add(0, -0.5, 0).getBlock().getType();
+
+        if (blockUnderPlayer.equals(Material.AIR)) {
+            player.sendMessage("§cVous ne pouvez pas utiliser cette commande dans les airs");
+            return;
+        }
+
+        Location waypointLocation = new Location(player.getWorld(), waypoint.getX(), waypoint.getY(), waypoint.getZ());
+        player.teleport(player.getLocation().setDirection(waypointLocation.toVector().subtract(player.getLocation().toVector())));
+    }
+
+    @Subcommand("credits")
+    @Description("Affiche les crédits")
+    public void credits(Player player) {
+        player.sendMessage("""
+                §9[Waypoint command] §7réalisé par §6§nFnafgameur
+                §7- §bDiscord§7: §6@Fnafgameur
+                §7- §bGitHub§7: §6https://github.com/Fnafgameur""");
+    }
+
     private void sendHelpMessage(Player player) {
 
         String message = """
                 §7---------- §6§lWaypoints §7----------
-                §7Utilisation: /waypoint <add|remove|list>
-                §7- §eadd [nom] §7: Ajoute un waypoint
-                §7- §eremove [nom] §7: Supprime un waypoint
-                §7- §elist §7: Liste les waypoints""";
+                §7Aliases: §b/waypoint§7, §b/wp§7, §b/balise
+                §7- §bwaypoint §eadd [nom] §7: Ajoute un waypoint
+                §7- §bwaypoint §eremove [nom] §7: Supprime un waypoint
+                §7- §bwaypoint §elist §7: Liste les waypoints
+                §7- §bwaypoint §egoto [nom] §7: Ré-oriente la caméra vers un waypoint
+                §7- §bwaypoint §ecredits §7: Affiche les crédits
+                """;
 
         player.sendMessage(message);
     }

--- a/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
+++ b/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
@@ -158,6 +158,7 @@ public class WaypointCommand {
 
         String message = """
                 §7---------- §6§lWaypoints §7----------
+                §7Utilité: §fPermet de poser des balises pour marquer des coordonnées
                 §7Aliases: §b/waypoint§7, §b/wp§7, §b/balise
                 §7- §bwaypoint §eadd [nom] §7: Ajoute un waypoint
                 §7- §bwaypoint §eremove [nom] §7: Supprime un waypoint

--- a/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
+++ b/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
@@ -6,7 +6,6 @@ import fr.communaywen.core.waypoints.Waypoint;
 import fr.communaywen.core.waypoints.managers.WaypointManager;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.block.BlockType;
 import org.bukkit.entity.Player;
 import revxrsal.commands.annotation.*;
 

--- a/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
+++ b/src/main/java/fr/communaywen/core/waypoints/commands/WaypointCommand.java
@@ -1,0 +1,104 @@
+package fr.communaywen.core.waypoints.commands;
+
+import fr.communaywen.core.credit.Credit;
+import fr.communaywen.core.utils.database.Waypoints;
+import org.bukkit.entity.Player;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.DefaultFor;
+import revxrsal.commands.annotation.Description;
+import revxrsal.commands.annotation.Subcommand;
+
+import java.util.List;
+
+@Command({"waypoint", "wp", "balise"})
+@Credit("Fnafgameur")
+public class WaypointCommand {
+
+    private final WaypointManager waypointManager;
+
+    public WaypointCommand(WaypointManager waypointManager) {
+        this.waypointManager = waypointManager;
+    }
+
+    @DefaultFor("~")
+    @Description("Gestion des waypoints")
+    public void onCommand(Player player) {
+        sendHelpMessage(player);
+    }
+
+    @Subcommand("add")
+    @Description("Ajoute un waypoint")
+    public void add(Player player, String name) {
+
+        int nbOfWaypoints = Waypoints.getWaypointsCount(player.getUniqueId().toString());
+
+        if (nbOfWaypoints >= waypointManager.getMaxWaypoints()) {
+            player.sendMessage("§cVous avez atteint le nombre maximum de waypoints (" + waypointManager.getMaxWaypoints() + ")");
+            return;
+        }
+
+        name = name.replace(" ", "_");
+
+        if (Waypoints.waypointExist(player.getUniqueId().toString(), name)) {
+            player.sendMessage("§cUn waypoint avec ce nom existe déjà");
+            return;
+        }
+
+        boolean successState = Waypoints.addWaypoint(player.getUniqueId().toString(), name, player.getLocation());
+
+        if (successState) {
+            player.sendMessage("§aWaypoint '" + name + "' ajouté avec succès");
+            return;
+        }
+        player.sendMessage("§cErreur lors de l'ajout du waypoint");
+    }
+
+    @Subcommand("remove")
+    @Description("Supprime un waypoint")
+    public void remove(Player player, String name) {
+
+        boolean successState = Waypoints.removeWaypoint(player.getUniqueId().toString(), name);
+
+        if (successState) {
+            player.sendMessage("§aWaypoint '" + name + "' supprimé avec succès");
+            return;
+        }
+        player.sendMessage("§cErreur lors de la suppression du waypoint, avez-vous bien écrit le nom ?");
+    }
+
+    @Subcommand("list")
+    @Description("Liste les waypoints")
+    public void list(Player player) {
+        List<String> waypoints = Waypoints.getWaypoints(player.getUniqueId().toString());
+
+        if (waypoints.isEmpty()) {
+            player.sendMessage("§cVous n'avez aucun waypoint");
+            return;
+        }
+
+        StringBuilder message = new StringBuilder("§7---------- §6§lWaypoints §7----------\n");
+
+        for (String waypoint : waypoints) {
+
+            message.append("§7")
+                    .append(waypoints.indexOf(waypoint))
+                    .append(" -§e ")
+                    .append(waypoint)
+                    .append("\n");
+        }
+
+        player.sendMessage(message.toString());
+    }
+
+    private void sendHelpMessage(Player player) {
+
+        String message = """
+                §7---------- §6§lWaypoints §7----------
+                §7Utilisation: /waypoint <add|remove|list>
+                §7- §eadd [nom] §7: Ajoute un waypoint
+                §7- §eremove [nom] §7: Supprime un waypoint
+                §7- §elist §7: Liste les waypoints""";
+
+        player.sendMessage(message);
+    }
+}

--- a/src/main/java/fr/communaywen/core/waypoints/commands/WaypointManager.java
+++ b/src/main/java/fr/communaywen/core/waypoints/commands/WaypointManager.java
@@ -1,0 +1,16 @@
+package fr.communaywen.core.waypoints.commands;
+
+import lombok.Getter;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class WaypointManager {
+
+    private FileConfiguration waypointConfig;
+    @Getter
+    private int maxWaypoints;
+
+    public WaypointManager(FileConfiguration waypointConfig) {
+        this.waypointConfig = waypointConfig;
+        this.maxWaypoints = waypointConfig.getInt("maxWaypoints");
+    }
+}

--- a/src/main/java/fr/communaywen/core/waypoints/managers/WaypointManager.java
+++ b/src/main/java/fr/communaywen/core/waypoints/managers/WaypointManager.java
@@ -3,9 +3,9 @@ package fr.communaywen.core.waypoints.managers;
 import lombok.Getter;
 import org.bukkit.configuration.file.FileConfiguration;
 
+@Getter
 public class WaypointManager {
 
-    @Getter
     private final int maxWaypoints;
 
     public WaypointManager(FileConfiguration waypointConfig) {

--- a/src/main/java/fr/communaywen/core/waypoints/managers/WaypointManager.java
+++ b/src/main/java/fr/communaywen/core/waypoints/managers/WaypointManager.java
@@ -1,16 +1,14 @@
-package fr.communaywen.core.waypoints.commands;
+package fr.communaywen.core.waypoints.managers;
 
 import lombok.Getter;
 import org.bukkit.configuration.file.FileConfiguration;
 
 public class WaypointManager {
 
-    private FileConfiguration waypointConfig;
     @Getter
-    private int maxWaypoints;
+    private final int maxWaypoints;
 
     public WaypointManager(FileConfiguration waypointConfig) {
-        this.waypointConfig = waypointConfig;
         this.maxWaypoints = waypointConfig.getInt("maxWaypoints");
     }
 }

--- a/src/main/java/fr/communaywen/core/waypoints/managers/WaypointManager.java
+++ b/src/main/java/fr/communaywen/core/waypoints/managers/WaypointManager.java
@@ -6,6 +6,10 @@ import org.bukkit.configuration.file.FileConfiguration;
 @Getter
 public class WaypointManager {
 
+    /**
+     * The maximum amount of waypoints a player can have
+     * (can be changed in the waypoints.yml config file)
+     */
     private final int maxWaypoints;
 
     public WaypointManager(FileConfiguration waypointConfig) {

--- a/src/main/resources/waypoints.yml
+++ b/src/main/resources/waypoints.yml
@@ -1,0 +1,1 @@
+maxWaypoints: 15


### PR DESCRIPTION
*Avez-vous lu le [Code de Conduite](https://github.com/Margouta/PluginOpenMC/blob/main/CODE_OF_CONDUCT.md)?*:
*Oui*

*Votre code se compile-t-il en local ?*: 
*Oui*

*Avez-vous supprimé les imports inutilisés ?*: *Oui*
## Décrivez vos changements
Ajout de la commande principale "/waypoint" (ou waypoints, wp, balise) ainsi que de sous-commandes (add, remove, list, goto, help et credits).
Cette commande permet de poser des waypoints dans les mondes afin de sauvegarder des coordonnées tout en leur donnant un nom.
Le nombre de waypoints maximum par joueur peut être défini dans le fichier config "waypoints.yml", nombre par défaut : 15.
Les waypoints sont stockés en BDD dans la table "waypoints" contenant les colonnes : player_uuid, waypoint_name, x, y, z, world, date.

**Les sous-commandes** : 
- add [nom] : permet d'ajouter un waypoint ayant les coordonnées du joueur
- remove [nom] : permet de supprimer un waypoint en spécifiant son nom
- list : permet de lister tous les waypoints du joueur exécutant la commande
- goto [nom] : permet d'orienter la caméra dans la direction de là où se trouve le waypoint
- help : permet d'avoir plus d'infos concernant cette commande
- credits : permet d'afficher les crédits