### PR TITLE
Modification du système de tombe dans l'eau

### DIFF
--- a/src/main/java/fr/communaywen/core/corpse/CorpseManager.java
+++ b/src/main/java/fr/communaywen/core/corpse/CorpseManager.java
@@ -47,7 +47,7 @@ public class CorpseManager implements Listener {
         for (CorpseBlock corpseBlock : corpses.keySet()) {
             Location corpseLocation = corpseBlock.getLocation();
 
-            if (areLocationsClose(loc, corpseLocation, 2)) {
+            if (areLocationsClose(loc, corpseLocation, 1.2)) {
                 CorpseMenu corpseMenu = corpses.get(corpseBlock);
 
                 if (corpseMenu != null && corpseMenu.isOwner(p)) {

--- a/src/main/java/fr/communaywen/core/corpse/CorpseManager.java
+++ b/src/main/java/fr/communaywen/core/corpse/CorpseManager.java
@@ -12,9 +12,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 @Feature("Tombe")
 @Credit("Martinouxx")
@@ -126,4 +124,13 @@ public class CorpseManager implements Listener {
         }
         return false;
     }
+
+    public List<Location> getGraveLocations() {
+        List<Location> locations = new ArrayList<>();
+        for (CorpseBlock corpseBlock : corpses.keySet()) {
+            locations.add(corpseBlock.getLocation());
+        }
+        return locations;
+    }
+
 }

--- a/src/main/java/fr/communaywen/core/listeners/CorpseListener.java
+++ b/src/main/java/fr/communaywen/core/listeners/CorpseListener.java
@@ -14,6 +14,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.Location;
@@ -36,9 +37,9 @@ public class CorpseListener implements Listener {
         Player player = e.getEntity();
 
         boolean waterNearby = false;
-        for (int x = -10; x <= 10; x++) {
-            for (int y = -10; y <= 10; y++) {
-                for (int z = -10; z <= 10; z++) {
+        for (int x = -7; x <= 7; x++) {
+            for (int y = -7; y <= 7; y++) {
+                for (int z = -7; z <= 7; z++) {
                     Block block = player.getLocation().add(x, y, z).getBlock();
                     if (block.getType() == Material.WATER) {
                         waterNearby = true;
@@ -132,25 +133,22 @@ public class CorpseListener implements Listener {
     }
 
     @EventHandler
-    public void onBlockPlace(BlockPlaceEvent e) {
+    public void onBlockPlace(PlayerBucketEmptyEvent e) {
         Player player = e.getPlayer();
-        Block block = e.getBlockPlaced();
 
-        if (block.getType() == Material.WATER || block.getType() == Material.WATER_BUCKET) {
-            Location blockLocation = block.getLocation();
-            List<Location> graveLocations = corpseManager.getGraveLocations();
+        Location blockLocation = e.getBlock().getLocation();
+        List<Location> graveLocations = corpseManager.getGraveLocations();
 
-            for (Location graveLocation : graveLocations) {
-                if (blockLocation.getWorld().equals(graveLocation.getWorld())) {
-                    double distance = blockLocation.distance(graveLocation);
-                    if (distance <= 20 ||
-                            (blockLocation.getBlockX() == graveLocation.getBlockX() &&
-                                    blockLocation.getBlockZ() == graveLocation.getBlockZ() &&
-                                    blockLocation.getBlockY() >= graveLocation.getBlockY())) {
-                        e.setCancelled(true);
-                        player.sendMessage("§cVous ne pouvez pas placer de l'eau près d'une tombe.");
-                        return;
-                    }
+        for (Location graveLocation : graveLocations) {
+            if (blockLocation.getWorld().equals(graveLocation.getWorld())) {
+                double distance = blockLocation.distance(graveLocation);
+                if (distance <= 12 ||
+                        (blockLocation.getBlockX() == graveLocation.getBlockX() &&
+                                blockLocation.getBlockZ() == graveLocation.getBlockZ() &&
+                                blockLocation.getBlockY() >= graveLocation.getBlockY())) {
+                    e.setCancelled(true);
+                    player.sendMessage("§cVous ne pouvez pas placer de l'eau près d'une tombe.");
+                    return;
                 }
             }
         }

--- a/src/main/java/fr/communaywen/core/listeners/CorpseListener.java
+++ b/src/main/java/fr/communaywen/core/listeners/CorpseListener.java
@@ -10,11 +10,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
+import org.bukkit.Location;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -124,6 +126,31 @@ public class CorpseListener implements Listener {
                 if (!player.getUniqueId().equals(uuid)) {
                     e.setCancelled(true);
                     return;
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent e) {
+        Player player = e.getPlayer();
+        Block block = e.getBlockPlaced();
+
+        if (block.getType() == Material.WATER || block.getType() == Material.WATER_BUCKET) {
+            Location blockLocation = block.getLocation();
+            List<Location> graveLocations = corpseManager.getGraveLocations();
+
+            for (Location graveLocation : graveLocations) {
+                if (blockLocation.getWorld().equals(graveLocation.getWorld())) {
+                    double distance = blockLocation.distance(graveLocation);
+                    if (distance <= 20 ||
+                            (blockLocation.getBlockX() == graveLocation.getBlockX() &&
+                                    blockLocation.getBlockZ() == graveLocation.getBlockZ() &&
+                                    blockLocation.getBlockY() >= graveLocation.getBlockY())) {
+                        e.setCancelled(true);
+                        player.sendMessage("§cVous ne pouvez pas placer de l'eau près d'une tombe.");
+                        return;
+                    }
                 }
             }
         }

--- a/src/main/java/fr/communaywen/core/listeners/CorpseListener.java
+++ b/src/main/java/fr/communaywen/core/listeners/CorpseListener.java
@@ -34,9 +34,9 @@ public class CorpseListener implements Listener {
         Player player = e.getEntity();
 
         boolean waterNearby = false;
-        for (int x = -3; x <= 3; x++) {
-            for (int y = -3; y <= 3; y++) {
-                for (int z = -3; z <= 3; z++) {
+        for (int x = -10; x <= 10; x++) {
+            for (int y = -10; y <= 10; y++) {
+                for (int z = -10; z <= 10; z++) {
                     Block block = player.getLocation().add(x, y, z).getBlock();
                     if (block.getType() == Material.WATER) {
                         waterNearby = true;


### PR DESCRIPTION
En attendant qu'ItemsAdder réparer le bug du cassage de bloc transparent avec de l'eau, j'ai fait que si un joueur mort est proche de l'eau alors ça ne mets pas de tombe mais ça drop les items au sol uniquement récupérable par lui (despawn : 5min (vu que vanilla))