### PR TITLE
Update build.gradle, ajout de purpur

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,7 @@ repositories {
     mavenCentral()
     mavenLocal()
     maven {
-        name = "spigotmc-repo"
-        url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+        url "https://repo.purpurmc.org/snapshots"
     }
     maven {
         name = "reposiliteRepositoryReleases"
@@ -30,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT'
+    compileOnly "org.purpurmc.purpur:purpur-api:1.20.6-R0.1-SNAPSHOT"
     implementation 'dev.xernas:menulib:1.1.0'
     // Jetbrains annotations (@NotNull, @Nullable)
     implementation 'org.jetbrains:annotations:24.1.0'


### PR DESCRIPTION
Update build.gradle pour ajouter l'api de purpur au lieu de spigot