### PR TITLE
modif du .gitignore pour eviter d'avoir des problèmes à chaque fois qu'on veut pull dû à la modification du config.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+#config.yml contains bdd logins and passwords
+/src/main/resources/config.yml
+
 ### Project ###
 
 /builds/


### PR DESCRIPTION
ajout du config.yml dans le gitignore car il est personnel à chaque dev car il contient les logins et passwords de sa base de données
